### PR TITLE
Disable service worker

### DIFF
--- a/jupyter-lite.json
+++ b/jupyter-lite.json
@@ -1,0 +1,9 @@
+{
+    "jupyter-lite-schema-version": 0,
+    "jupyter-config-data": {
+        "appName": "JupyterLite Nao",
+        "disabledExtensions": [
+            "@jupyterlite/server-extension:service-worker"
+        ]
+    }
+}


### PR DESCRIPTION
Service worker manages the content and requires http**s**, but it is not needed in this case.