### PR TITLE
Simplify asyncio syntax

### DIFF
--- a/content/introduction.ipynb
+++ b/content/introduction.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -45,7 +44,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -64,7 +62,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -127,7 +124,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -165,7 +161,7 @@
    },
    "outputs": [],
    "source": [
-    "robot_summary = asyncio.ensure_future(motion.async_getSummary())"
+    "robot_summary = motion.getSummary()"
    ]
   },
   {
@@ -246,7 +242,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -269,7 +264,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -311,7 +305,7 @@
     "fps = 20\n",
     "sub_ID = \"jupy\"\n",
     "\n",
-    "cam_sub = asyncio.ensure_future(vid.async_subscribeCamera(sub_ID, 0, resolution, color_space, fps))"
+    "cam_sub = vid.subscribeCamera(sub_ID, 0, resolution, color_space, fps)"
    ]
   },
   {
@@ -334,7 +328,7 @@
    },
    "outputs": [],
    "source": [
-    "img_future = asyncio.ensure_future(vid.async_getImageRemote(sub_name))"
+    "img_future = vid.getImageRemote(sub_name)"
    ]
   },
   {
@@ -387,7 +381,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -425,9 +418,9 @@
    "outputs": [],
    "source": [
     "async def little_dance():\n",
-    "    await motion.async_wakeUp()\n",
-    "    await animate.async_run(\"animations/Stand/Gestures/Hey_2\")\n",
-    "    await motion.async_rest()"
+    "    await motion.wakeUp()\n",
+    "    await animate.run(\"animations/Stand/Gestures/Hey_2\")\n",
+    "    await motion.rest()"
    ]
   },
   {
@@ -442,7 +435,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -470,9 +462,16 @@
    "outputs": [],
    "source": [
     "out = Output()\n",
-    "res = asyncio.ensure_future(w.service(\"ALLeds\", out).async_rasta(\"gibberish\"))\n",
+    "res = w.service(\"ALLeds\", out).rasta(\"gibberish\")\n",
     "out"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/content/introduction.ipynb
+++ b/content/introduction.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -13,7 +14,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install ipynao==0.4.1"
+    "%pip install ipynao==0.5.0"
    ]
   },
   {
@@ -44,6 +45,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -62,6 +64,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -124,6 +127,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -242,6 +246,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -264,6 +269,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -381,6 +387,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -435,6 +442,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/ipynao/_frontend.py
+++ b/ipynao/_frontend.py
@@ -9,4 +9,4 @@ Information about the frontend package of the widgets.
 """
 
 module_name = "ipynao"
-module_version = "^0.4.1"
+module_version = "^0.5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ipynao",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ipynao",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyter-widgets/base": "^1.1.10 || ^2 || ^3 || ^4 || ^5 || ^6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipynao",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A widget library for controlling Nao",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 dependencies = [
     "ipywidgets>=7.0.0",
 ]
-version = "0.4.1"
+version = "0.5.0"
 
 [project.optional-dependencies]
 docs = [
@@ -104,7 +104,7 @@ file = [
 ]
 
 [tool.tbump.version]
-current = "0.4.1"
+current = "0.5.0"
 regex = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)((?P<channel>a|b|rc|.dev)(?P<release>\\d+))?"
 
 [tool.tbump.git]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ ipympl>=0.8.2
 ipycanvas>=0.9.1
 
 # Python: ipynao library for Nao robot
-ipynao>=0.4.1
+ipynao>=0.5.0
 
 # For examples with images
 Pillow

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -155,11 +155,6 @@ export class NaoRobotModel extends DOMWidgetModel {
     // the request ID is the next one which is used to call the service
     const naoService = await servicePromise
       .then((resolution: any) => {
-        this.send({
-          isError: false,
-          data: true, // TODO: resolution ?? true,
-          requestID: requestID + 1, // Note above
-        });
         return resolution;
       })
       .catch((rejection: string) => {


### PR DESCRIPTION
New features: 
- Merge `async_` and non-`async_` service calls into their simplified versions
- Hides extra `asyncio.ensure_future` from the user. Services can be called normally
```python
async some_fun():
    await nao.service("ALTextToSpeech", output).say("hello")
asyncio.ensure_future(some_fun())
```
```python
nao.service("ALLeds", output).rasta(4)
```

Not included (yet):
- The creation of services still does not wait for a response from the frontend